### PR TITLE
support choosing digest algorithm for rsa (sha1 or sha256 or sha512)

### DIFF
--- a/KryptoTests/DigestAlgorithmParsingTests.swift
+++ b/KryptoTests/DigestAlgorithmParsingTests.swift
@@ -1,0 +1,95 @@
+//
+//  DigestAlgorithmParsingTests.swift
+//  Kryptonite
+//
+//  Created by Alex Grinman on 5/9/17.
+//  Copyright © 2017 KryptCo. All rights reserved.
+//
+
+import XCTest
+
+class DigestAlgorithmParsingTests: XCTestCase {
+    
+    struct testcase {
+        var session:Data
+        var user:String
+        var digest:DigestType
+        var data:SSHMessage
+    }
+    
+    let testCaseRSA = testcase(session: try! "WtlCXAXyTdQKuTBnYTRT6obHnvB6G/kAGQclK2g4Jzc=".fromBase64(), user: "git", digest: .sha1, data: try!SSHMessage("AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()))
+    
+    let testCaseRSASha256 = testcase(session: try! "UUTjo7EhM6/i0iw727smr9bq+d/h2LBt1ISh4YwMH3I=".fromBase64(), user: "testuser", digest: .sha256, data: try! SSHMessage("AAAAIFFE46OxITOv4tIsO9u7Jq/W6vnf4diwbdSEoeGMDB9yMgAAAAh0ZXN0dXNlcgAAAA5zc2gtY29ubmVjdGlvbgAAAAlwdWJsaWNrZXkBAAAADHJzYS1zaGEyLTI1Ng==".fromBase64()))
+    
+    let testCaseRSASha512 = testcase(session: try! "mmWe3ZJGE+1hCoV9lwnCxJisggxoCM7GFOWsz/M1XpY=".fromBase64(), user: "root", digest: .sha512, data: try! SSHMessage("AAAAIJplnt2SRhPtYQqFfZcJwsSYrIIMaAjOxhTlrM/zNV6WMgAAAARyb290AAAADnNzaC1jb25uZWN0aW9uAAAACXB1YmxpY2tleQEAAAAMcnNhLXNoYTItNTEy".fromBase64()))
+
+    let testCaseEd25519 = testcase(session: try! "AVdBTzgU4SB5cnSf9/DMaTnxLR0Sk/4kF3+xkXyQshE=".fromBase64(), user: "root", digest: .ed25519, data: try! SSHMessage("AAAAIAFXQU84FOEgeXJ0n/fwzGk58S0dEpP+JBd/sZF8kLIRMgAAAARyb290AAAADnNzaC1jb25uZWN0aW9uAAAACXB1YmxpY2tleQEAAAALc3NoLWVkMjU1MTk=".fromBase64()))
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testParseSSHUserAuthMessages() {
+        
+        for test in [testCaseRSA, testCaseRSASha256, testCaseRSASha512, testCaseEd25519] {
+            
+            do {
+                let (session, user, digestType) = try SignRequest.parse(requestData: test.data)
+                
+                XCTAssertEqual(session, test.session)
+                XCTAssertEqual(user, test.user)
+                XCTAssertEqual(digestType, test.digest)
+                
+            } catch {
+                XCTFail("error: \(error)")
+            }
+            
+        }
+
+    }
+    
+    func testBadSSHMessageParsingWrongLen() {
+        do {
+            var correctData = try "AAAAIE5yHvfefACpf4gX/T7jFE0kbT5VFAQA5dOaa817rvN5MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
+            
+            let session = try correctData.popData()
+            let user = try correctData.popData()
+            let byte = try correctData.popByte()
+
+            // add back but leave out a few user bytes
+            var data = Data(bytes: session.bigEndianByteSize())
+            data.append(session)
+            
+            data.append(contentsOf: user.bigEndianByteSize())
+            data.append(user.subdata(in: 0 ..< user.count - 2))
+            data.append(contentsOf: [byte])
+            data.append(correctData)
+            
+            let (_, _, _) = try SignRequest.parse(requestData: data)
+            XCTFail("broken ssh message data parsed correctly somehow!")
+        } catch {
+            XCTAssert(error is SSHMessageParsingError)
+        }
+    }
+    
+    func testBadSSHMessageParsingRandomData() {
+        
+        let dataLength = try! "AAAAIE5yHvfefACpf4gX/T7jFE0kbT5VFAQA5dOaa817rvN5MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64().count
+
+        for _ in 0 ..< 9 {
+            do {
+                let randomData = try Data.random(size: dataLength)
+                let (_, _, _) = try SignRequest.parse(requestData: randomData)
+                XCTFail("random ssh message data parsed correctly somehow!")                
+            } catch {
+                XCTAssert(error is SSHMessageParsingError)
+            }
+        }
+    }
+
+    
+}

--- a/KryptoTests/SSHHostVerificationTests.swift
+++ b/KryptoTests/SSHHostVerificationTests.swift
@@ -1,5 +1,5 @@
 //
-//  SSHVerificationTests.swift
+//  SSHHostVerificationTests.swift
 //  Kryptonite
 //
 //  Created by Kevin King on 3/29/17.
@@ -20,7 +20,7 @@ class HostAuthTestCase {
     }
 }
 
-class SSHVerificationTests: XCTestCase {
+class SSHHostVerificationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
@@ -33,32 +33,40 @@ class SSHVerificationTests: XCTestCase {
     let rsaSigEqualSizeModulus = HostAuthTestCase(
         pk: "AAAAB3NzaC1yc2EAAAADAQABAAABAQCy+nQ5jr9m4Mil8Llh6nqdN8uX25eljQfaoFdl8K1ufNt26BulxMn41prse+k5cDueL6w06xglVtx1FU4S8uhkbB2WZo05shnUvoNXU6hfQR0nT0Esfk8PqjOl69JVnV8NmVGtSmnMVgJNlvXdQrvvWcDYyI8RLR5bvVFrvMhjSOk8Vb81eJ5TqgJ/Ae+UsG1+uSjySORIuuv7vFsQNB93RE8d68LjQ6QDZB8j02UFNlwsGb+SKEufAlkOgGHTDS3P6lxZLc0AW5691vL58D253CpzNBcnu5llbrdfr/XKoOCQusMOclBN69LrbPWvTx6Tvs3CBwH7XY6WuATId+Wr",
         sig: "AAAAB3NzaC1yc2EAAAEADQc5AG5LwQyee6txeY+XvrQ8/+ihJ84vz4nK4Jtpv3r6efPvq20UgAbTzhx/03RGdo+nZtRumCWDFHrW45unEdcSHuzlrm9v9UVwpKseQO89SnDpA2Tt6UBlJZuVixkldlhFlmrun+GeAxYHxVLeSEL7oaZ/TicQnQFMCvcfD82YMUXxk81SIssEtUVyZOq9Qi2h37xwNz+sSYO37Hkof6nYuJ529DgxcRiJEzIRN03oNoglRi8IZz8LHBLxu3dr/jikxXkZ1/YFt/FMGjhDlp3Yxqj2CPxJ+uyfaCJgbLcgv8tfhSiE8DxOK/WMyP6bLxnC04AOcsrY7Cn9BdvMpw==",
-        data: "AAAAIKce60VmSoQEa5zV24zb/yEZnVxNnZ4rxPgFYVg29uhUAAAAAAVrZXZpbgo="
+        data: "AAAAIKce60VmSoQEa5zV24zb/yEZnVxNnZ4rxPgFYVg29uhUMgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh"
     )
 
 
     let rsaSigSmallerThanModulus = HostAuthTestCase(
         pk: "AAAAB3NzaC1yc2EAAAADAQABAAABAQCy+nQ5jr9m4Mil8Llh6nqdN8uX25eljQfaoFdl8K1ufNt26BulxMn41prse+k5cDueL6w06xglVtx1FU4S8uhkbB2WZo05shnUvoNXU6hfQR0nT0Esfk8PqjOl69JVnV8NmVGtSmnMVgJNlvXdQrvvWcDYyI8RLR5bvVFrvMhjSOk8Vb81eJ5TqgJ/Ae+UsG1+uSjySORIuuv7vFsQNB93RE8d68LjQ6QDZB8j02UFNlwsGb+SKEufAlkOgGHTDS3P6lxZLc0AW5691vL58D253CpzNBcnu5llbrdfr/XKoOCQusMOclBN69LrbPWvTx6Tvs3CBwH7XY6WuATId+Wr",
         sig: "AAAAB3NzaC1yc2EAAAEAAGFtFeQVT+Js31n+S3YuAs3Hx08CKv8XAREoqm+uq40j8qPQG/fRCqB3lT+PkwDdLibqIbLCHKAThJq9ft+hZxa/xv3LegxjJvNhXHR8pk2BxnZXQvs6RmJjFHUJHY8/bylA+zSYssOYdeq6PJogTudJ9NenlksmFPmQ4VkCdp3JPo2Y+JEuT7CcSNYL4zrQMXXLTfZV0/SZ0E3Z+ZBJttQI8c68WNd++rPt7tFkvmbb/k7TtSt2pwIZqHX15WKkm/41An/WqXcUwk2VMdUf36SG5X2qPzCC9yPAqphhSKitFOXQaP3nEWGocbSb6vpBACb+MRbjdFGkdCJDfAzQvQ==",
-        data: "AAAAIE5yHvfefACpf4gX/T7jFE0kbT5VFAQA5dOaa817rvN5AAAAAAVrZXZpbgo="
+        data: "AAAAIE5yHvfefACpf4gX/T7jFE0kbT5VFAQA5dOaa817rvN5MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh"
     )
 
     let ecdsaCase = HostAuthTestCase(
             pk: "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFsz+iDSG34GRKn6M6qhbn7BTQrRcz5l+ZE9sbcBvvUJlGahkvGscr/y2ucl85XQFYkGdV04cfNr1jMoDicQHRM=",
             sig: "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAABJAAAAIFvpL0Zg1oNIx5fD2y9Gf2zwXPrWap4XuMz+WutTVQK9AAAAIQC623uwOYif3Hg6gOapgRslsVAY9W0GkqFxbfq7sHFFtA==",
-            data: "AAAAILqtiL9S+34rm3Jetl4QpbCUFmeLNM31u6go/e702npgAAAAAAVrZXZpbgo="
+            data: "AAAAILqtiL9S+34rm3Jetl4QpbCUFmeLNM31u6go/e702npgMgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh"
     )
 
     let ed25519Case = HostAuthTestCase(
         pk: "AAAAC3NzaC1lZDI1NTE5AAAAIK4WjSfJ9SmETrpAjw7+0znqMsHTXzY/b6AXCRoQzzuI",
         sig: "AAAAC3NzaC1lZDI1NTE5AAAAQFBf15H9MeZ32f3cgdfzicIM70teC23wMDVFN/+gRW73YyjiZpFamjJ56jjVv+fZVsoaijs42/RlOV/wMNI+3w8=",
-        data: "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo="
+        data: "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh"
     )
 
     func testHostAuth() {
+    
+        print("Doing rsaSigSmallerThanModulus")
         runCase(testCase: rsaSigSmallerThanModulus)
+        
+        print("Doing rsaSigEqualSizeModulus")
         runCase(testCase: rsaSigEqualSizeModulus)
+        
+        print("Doing ecdsaCase")
         runCase(testCase: ecdsaCase)
+        
+        print("Doing ed25519Case")
         runCase(testCase: ed25519Case)
     }
 
@@ -73,7 +81,7 @@ class SSHVerificationTests: XCTestCase {
                     hostNames: []
                     )
             )
-            XCTAssert(signRequest.user! == "kevin")
+            XCTAssert(signRequest.user == "git")
             XCTAssert(signRequest.hostAuth != nil)
         } catch let e {
             XCTFail("\(e)")
@@ -90,7 +98,7 @@ class SSHVerificationTests: XCTestCase {
             let _ = try SignRequest(data: invalidData, fingerprint: fp, hostAuth: nil)
             XCTFail("expected exception")
         } catch let e {
-            guard let _ = e as? SignRequest.InvalidSessionData else {
+            guard let _ = e as? SSHMessageParsingError else {
                 XCTFail("\(e)")
                 return
             }

--- a/KryptoTests/SiloTests.swift
+++ b/KryptoTests/SiloTests.swift
@@ -29,7 +29,7 @@ class SiloTests: XCTestCase {
             let session = try Session(pairing: pairing)
 
 
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion)
             try Silo.shared.handle(request: request, session: session, communicationMedium: .remoteNotification)
             XCTFail("expected exception")
         } catch let e {
@@ -47,7 +47,7 @@ class SiloTests: XCTestCase {
 
             SessionManager.shared.add(session: session, temporary: true)
 
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion)
             try Silo.shared.handle(request: request, session: session, communicationMedium: .remoteNotification)
         } catch let e {
             XCTFail("\(e)")
@@ -61,7 +61,7 @@ class SiloTests: XCTestCase {
 
             SessionManager.shared.add(session: session, temporary: true)
 
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion)
             try Silo.shared.handle(request: request, session: session, communicationMedium: .remoteNotification)
 
             SessionManager.shared.remove(session: session)
@@ -83,9 +83,9 @@ class SiloTests: XCTestCase {
     func testPendingRequest() {
         do {
             let fp = try KeyManager.sharedInstance().keyPair.publicKey.fingerprint().toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
@@ -109,9 +109,9 @@ class SiloTests: XCTestCase {
     func testOldRequest() {
         do {
             let fp = try KeyManager.sharedInstance().keyPair.publicKey.fingerprint().toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 - Properties.requestTimeTolerance * 3), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 - Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
@@ -135,9 +135,9 @@ class SiloTests: XCTestCase {
     func testFutureRequest() {
         do {
             let fp = try KeyManager.sharedInstance().keyPair.publicKey.fingerprint().toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 + Properties.requestTimeTolerance * 3), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 + Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
@@ -161,9 +161,9 @@ class SiloTests: XCTestCase {
     func testValidKey() {
         do {
             let fp = try KeyManager.sharedInstance().keyPair.publicKey.fingerprint().toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
@@ -179,9 +179,9 @@ class SiloTests: XCTestCase {
     func testValidKeyTwice() {
         do {
             let fp = try KeyManager.sharedInstance().keyPair.publicKey.fingerprint().toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
@@ -198,9 +198,9 @@ class SiloTests: XCTestCase {
     func testInvalidKey() {
         do {
             let randomFp = try Data.random(size: 32).toBase64()
-            let data = try "AAAAIPETRn52JvtGonHlvKDDzk02/9p8GKioagvG+nEU3+h9AAAAAAVrZXZpbgo=".fromBase64()
+            let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: randomFp, hostAuth: nil)
-            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, sign: sign)
+            let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, sign: sign)
             let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 

--- a/Kryptonite.xcodeproj/project.pbxproj
+++ b/Kryptonite.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 		FAB5179B1E54D54F0032DD47 /* KeyPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA97C061D71447C00DDB725 /* KeyPair.swift */; };
 		FAB5179C1E54D54F0032DD47 /* Wrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFE546E1D7B9C1400391FDD /* Wrap.swift */; };
 		FAB5179D1E54D54F0032DD47 /* Hash.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAD091C1D78BA0000EAB665 /* Hash.swift */; };
-		FAB5179E1E54D54F0032DD47 /* SSHKeyFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHKeyFormat.swift */; };
+		FAB5179E1E54D54F0032DD47 /* SSHFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHFormat.swift */; };
 		FAB5179F1E54D54F0032DD47 /* CryptoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04921D73CDD2002A7AFD /* CryptoError.swift */; };
 		FAB517A11E54D54F0032DD47 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04941D73ECE2002A7AFD /* Util.swift */; };
 		FAB517A21E54D54F0032DD47 /* KeychainStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA69729C1D78DE15002F34D6 /* KeychainStorage.swift */; };
@@ -219,6 +219,9 @@
 		FACBEFEB1D779D6E005D71B9 /* CreateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBEFEA1D779D6E005D71B9 /* CreateController.swift */; };
 		FACBEFEE1D77A2B7005D71B9 /* SetupController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBEFED1D77A2B7005D71B9 /* SetupController.swift */; };
 		FACDE4371DA036FD0065E1E1 /* SessionsEmptyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACDE4361DA036FD0065E1E1 /* SessionsEmptyController.swift */; };
+		FACE33551EC186DC003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
+		FACE33661EC186E8003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
+		FACE33671EC186E9003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
 		FAD361F71DF08F9E00D17BAB /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD361F61DF08F9E00D17BAB /* Connectivity.swift */; };
 		FADD714A1D772F8200DA5112 /* Date+KR.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD71491D772F8200DA5112 /* Date+KR.swift */; };
 		FAE45B991E64750E00A583AB /* RSAKeyPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE45B981E64750E00A583AB /* RSAKeyPair.swift */; };
@@ -247,13 +250,13 @@
 		FAE495971DBD89F100A97708 /* M13CheckboxPathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE495851DBD89F000A97708 /* M13CheckboxPathGenerator.swift */; };
 		FAE495981DBD89F100A97708 /* M13CheckboxRadioPathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE495861DBD89F000A97708 /* M13CheckboxRadioPathGenerator.swift */; };
 		FAE4959B1DBD98C400A97708 /* Approval.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FAE495991DBD98C400A97708 /* Approval.storyboard */; };
-		FAEE048C1D7369C3002A7AFD /* SSHKeyFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHKeyFormat.swift */; };
+		FAEE048C1D7369C3002A7AFD /* SSHFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHFormat.swift */; };
 		FAEE048E1D736AD3002A7AFD /* SoftwareLibraries in Resources */ = {isa = PBXBuildFile; fileRef = FAEE048D1D736AD3002A7AFD /* SoftwareLibraries */; };
 		FAEE04931D73CDD2002A7AFD /* CryptoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04921D73CDD2002A7AFD /* CryptoError.swift */; };
 		FAEE04951D73ECE2002A7AFD /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04941D73ECE2002A7AFD /* Util.swift */; };
 		FAEE049D1D74BCC3002A7AFD /* KryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE049C1D74BCC3002A7AFD /* KryptoTests.swift */; };
 		FAEE04A51D74BD47002A7AFD /* KeyPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA97C061D71447C00DDB725 /* KeyPair.swift */; };
-		FAEE04A61D74BD47002A7AFD /* SSHKeyFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHKeyFormat.swift */; };
+		FAEE04A61D74BD47002A7AFD /* SSHFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE048B1D7369C3002A7AFD /* SSHFormat.swift */; };
 		FAEE04A71D74BD47002A7AFD /* CryptoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04921D73CDD2002A7AFD /* CryptoError.swift */; };
 		FAEE04A81D74BD47002A7AFD /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE04941D73ECE2002A7AFD /* Util.swift */; };
 		FAF1E6221E031BB9003CBEA2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF1E6211E031BB9003CBEA2 /* NotificationService.swift */; };
@@ -633,6 +636,7 @@
 		FACBEFEA1D779D6E005D71B9 /* CreateController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateController.swift; sourceTree = "<group>"; };
 		FACBEFED1D77A2B7005D71B9 /* SetupController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupController.swift; sourceTree = "<group>"; };
 		FACDE4361DA036FD0065E1E1 /* SessionsEmptyController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionsEmptyController.swift; sourceTree = "<group>"; };
+		FACE33541EC186DC003EC6C0 /* SSHUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHUtil.swift; sourceTree = "<group>"; };
 		FAD361F61DF08F9E00D17BAB /* Connectivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
 		FADD71491D772F8200DA5112 /* Date+KR.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Date+KR.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FAE45B981E64750E00A583AB /* RSAKeyPair.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAKeyPair.swift; sourceTree = "<group>"; };
@@ -657,7 +661,7 @@
 		FAE495851DBD89F000A97708 /* M13CheckboxPathGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = M13CheckboxPathGenerator.swift; sourceTree = "<group>"; };
 		FAE495861DBD89F000A97708 /* M13CheckboxRadioPathGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = M13CheckboxRadioPathGenerator.swift; sourceTree = "<group>"; };
 		FAE4959A1DBD98C400A97708 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Approval.storyboard; sourceTree = "<group>"; };
-		FAEE048B1D7369C3002A7AFD /* SSHKeyFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SSHKeyFormat.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		FAEE048B1D7369C3002A7AFD /* SSHFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SSHFormat.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FAEE048D1D736AD3002A7AFD /* SoftwareLibraries */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SoftwareLibraries; sourceTree = "<group>"; };
 		FAEE04921D73CDD2002A7AFD /* CryptoError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CryptoError.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FAEE04941D73ECE2002A7AFD /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Util.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -1111,13 +1115,14 @@
 				FAA97C061D71447C00DDB725 /* KeyPair.swift */,
 				FAE45B981E64750E00A583AB /* RSAKeyPair.swift */,
 				FAE45B9C1E64AA3E00A583AB /* Ed25519.swift */,
-				FAEE048B1D7369C3002A7AFD /* SSHKeyFormat.swift */,
+				FAEE048B1D7369C3002A7AFD /* SSHFormat.swift */,
 				FAFE546E1D7B9C1400391FDD /* Wrap.swift */,
 				FAAD091C1D78BA0000EAB665 /* Hash.swift */,
 				FAEE04921D73CDD2002A7AFD /* CryptoError.swift */,
 				FAEE04941D73ECE2002A7AFD /* Util.swift */,
 				FA69729C1D78DE15002F34D6 /* KeychainStorage.swift */,
 				8D003DF11D90EDE30085ED21 /* Sodium.swift */,
+				FACE33541EC186DC003EC6C0 /* SSHUtil.swift */,
 			);
 			name = Krypto;
 			sourceTree = "<group>";
@@ -1778,7 +1783,7 @@
 				FAE495961DBD89F100A97708 /* M13CheckboxDisclosurePathGenerator.swift in Sources */,
 				FA4A84DF1E8D77910082274A /* TransportControl.swift in Sources */,
 				FACBEFEB1D779D6E005D71B9 /* CreateController.swift in Sources */,
-				FAEE048C1D7369C3002A7AFD /* SSHKeyFormat.swift in Sources */,
+				FAEE048C1D7369C3002A7AFD /* SSHFormat.swift in Sources */,
 				FAE4958D1DBD89F100A97708 /* M13CheckboxDotController.swift in Sources */,
 				FA16827A1D774D6000A7ED53 /* StringExtension.swift in Sources */,
 				FA16828B1EB2A8FE00D9CE40 /* KnownHosts.xcdatamodeld in Sources */,
@@ -1851,6 +1856,7 @@
 				FA8523CA1DBFDA5200D465D2 /* Version.swift in Sources */,
 				FA1682791D774D6000A7ED53 /* RSUPCEGenerator.swift in Sources */,
 				FAB664EF1DBFF18C0094896F /* Updater.swift in Sources */,
+				FACE33551EC186DC003EC6C0 /* SSHUtil.swift in Sources */,
 				FA61EF431D81D150009FD899 /* SessionManager.swift in Sources */,
 				FAE45B9D1E64AA3E00A583AB /* Ed25519.swift in Sources */,
 				FACAA4C41D897BC0000B9A01 /* LogGraph.swift in Sources */,
@@ -1908,9 +1914,10 @@
 				FAC873FF1E6A5148003D112E /* JSON+Seal.swift in Sources */,
 				8DCB60401E94468100E1B924 /* Response.swift in Sources */,
 				8DCB603B1E94458000E1B924 /* AnalyticsStub.swift in Sources */,
-				FAEE04A61D74BD47002A7AFD /* SSHKeyFormat.swift in Sources */,
+				FAEE04A61D74BD47002A7AFD /* SSHFormat.swift in Sources */,
 				8DCB604E1E9446D300E1B924 /* SQS.swift in Sources */,
 				FAC873F71E6A4DB9003D112E /* Pairing.swift in Sources */,
+				FACE33671EC186E9003EC6C0 /* SSHUtil.swift in Sources */,
 				8DCB60461E94469700E1B924 /* Policy.swift in Sources */,
 				FA6C5CF91D772B0D00CE2323 /* Log.swift in Sources */,
 				8DCB60481E9446CA00E1B924 /* TransportControl.swift in Sources */,
@@ -1953,6 +1960,7 @@
 				FAC874051E6F0E17003D112E /* Kryptonite.xcdatamodeld in Sources */,
 				FAB5179D1E54D54F0032DD47 /* Hash.swift in Sources */,
 				FAAE81981E5770DD002A9AE6 /* Bluetooth.swift in Sources */,
+				FACE33661EC186E8003EC6C0 /* SSHUtil.swift in Sources */,
 				FAAE81951E57706E002A9AE6 /* Silo.swift in Sources */,
 				FAB517BF1E54D7220032DD47 /* Mutex.swift in Sources */,
 				FA4A84E11E8DA75B0082274A /* SQS.swift in Sources */,
@@ -1967,7 +1975,7 @@
 				FA4A84E01E8DA7330082274A /* TransportControl.swift in Sources */,
 				FAB517951E54D52F0032DD47 /* Request.swift in Sources */,
 				FA1682A01EB2B2B200D9CE40 /* KnownHostManager.swift in Sources */,
-				FAB5179E1E54D54F0032DD47 /* SSHKeyFormat.swift in Sources */,
+				FAB5179E1E54D54F0032DD47 /* SSHFormat.swift in Sources */,
 				FAB517A71E54D5780032DD47 /* Date+KR.swift in Sources */,
 				FAB5179F1E54D54F0032DD47 /* CryptoError.swift in Sources */,
 				8DC860B31E57822A008CC974 /* HostAuth.swift in Sources */,

--- a/Kryptonite.xcodeproj/project.pbxproj
+++ b/Kryptonite.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		8D003DF31D90EDE30085ED21 /* Sodium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D003DF11D90EDE30085ED21 /* Sodium.swift */; };
 		8D003DF61D90EECE0085ED21 /* SodiumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D003DF41D90EECE0085ED21 /* SodiumTests.swift */; };
 		8D0CDC951D8789FB00CDBC3C /* Bluetooth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D0CDC941D8789FB00CDBC3C /* Bluetooth.swift */; };
-		8D45AFF61E8D739500E84A57 /* SSHVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D45AFF51E8D739500E84A57 /* SSHVerificationTests.swift */; };
+		8D45AFF61E8D739500E84A57 /* SSHHostVerificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D45AFF51E8D739500E84A57 /* SSHHostVerificationTests.swift */; };
 		8D45B0071E8D7C0600E84A57 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA6E1FF1D7A0AF9007D1B3A /* Request.swift */; };
 		8D45B0081E8D7CEA00E84A57 /* HostAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D83990B1E56063A0051C6BA /* HostAuth.swift */; };
 		8D45B00A1E8D7DBB00E84A57 /* libsshwire.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC38BC21E689785007445B4 /* libsshwire.a */; };
@@ -222,6 +222,7 @@
 		FACE33551EC186DC003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
 		FACE33661EC186E8003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
 		FACE33671EC186E9003EC6C0 /* SSHUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33541EC186DC003EC6C0 /* SSHUtil.swift */; };
+		FACE33691EC257F9003EC6C0 /* DigestAlgorithmParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACE33681EC257F9003EC6C0 /* DigestAlgorithmParsingTests.swift */; };
 		FAD361F71DF08F9E00D17BAB /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD361F61DF08F9E00D17BAB /* Connectivity.swift */; };
 		FADD714A1D772F8200DA5112 /* Date+KR.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADD71491D772F8200DA5112 /* Date+KR.swift */; };
 		FAE45B991E64750E00A583AB /* RSAKeyPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE45B981E64750E00A583AB /* RSAKeyPair.swift */; };
@@ -497,7 +498,7 @@
 		8D003DF11D90EDE30085ED21 /* Sodium.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sodium.swift; sourceTree = "<group>"; };
 		8D003DF41D90EECE0085ED21 /* SodiumTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SodiumTests.swift; sourceTree = "<group>"; };
 		8D0CDC941D8789FB00CDBC3C /* Bluetooth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bluetooth.swift; sourceTree = "<group>"; };
-		8D45AFF51E8D739500E84A57 /* SSHVerificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHVerificationTests.swift; sourceTree = "<group>"; };
+		8D45AFF51E8D739500E84A57 /* SSHHostVerificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHHostVerificationTests.swift; sourceTree = "<group>"; };
 		8D45B0091E8D7D6F00E84A57 /* Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
 		8D7941671D98732600F6E32E /* NetworkProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtocol.swift; sourceTree = "<group>"; };
 		8D83990B1E56063A0051C6BA /* HostAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostAuth.swift; sourceTree = "<group>"; };
@@ -637,6 +638,7 @@
 		FACBEFED1D77A2B7005D71B9 /* SetupController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetupController.swift; sourceTree = "<group>"; };
 		FACDE4361DA036FD0065E1E1 /* SessionsEmptyController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionsEmptyController.swift; sourceTree = "<group>"; };
 		FACE33541EC186DC003EC6C0 /* SSHUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SSHUtil.swift; sourceTree = "<group>"; };
+		FACE33681EC257F9003EC6C0 /* DigestAlgorithmParsingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DigestAlgorithmParsingTests.swift; sourceTree = "<group>"; };
 		FAD361F61DF08F9E00D17BAB /* Connectivity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
 		FADD71491D772F8200DA5112 /* Date+KR.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "Date+KR.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FAE45B981E64750E00A583AB /* RSAKeyPair.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAKeyPair.swift; sourceTree = "<group>"; };
@@ -1150,9 +1152,10 @@
 				FAC873F51E6A4D32003D112E /* PairingTests.swift */,
 				8D003DF41D90EECE0085ED21 /* SodiumTests.swift */,
 				FAEE049E1D74BCC3002A7AFD /* Info.plist */,
-				8D45AFF51E8D739500E84A57 /* SSHVerificationTests.swift */,
+				8D45AFF51E8D739500E84A57 /* SSHHostVerificationTests.swift */,
 				8D45B0091E8D7D6F00E84A57 /* Bridging-Header.h */,
 				8DCB60231E9442F300E1B924 /* SiloTests.swift */,
+				FACE33681EC257F9003EC6C0 /* DigestAlgorithmParsingTests.swift */,
 				8DCB603A1E94458000E1B924 /* AnalyticsStub.swift */,
 			);
 			path = KryptoTests;
@@ -1907,6 +1910,7 @@
 				8DCB60441E94468B00E1B924 /* NetworkProtocol.swift in Sources */,
 				8DCB60411E94468100E1B924 /* KeyManager.swift in Sources */,
 				FAC873FC1E6A4E9C003D112E /* KeychainStorage.swift in Sources */,
+				FACE33691EC257F9003EC6C0 /* DigestAlgorithmParsingTests.swift in Sources */,
 				8DCB604C1E9446D300E1B924 /* AWS.swift in Sources */,
 				8D003DF61D90EECE0085ED21 /* SodiumTests.swift in Sources */,
 				8DCB603C1E9445F200E1B924 /* Silo.swift in Sources */,
@@ -1939,7 +1943,7 @@
 				FAC873F61E6A4D32003D112E /* PairingTests.swift in Sources */,
 				8D45B0071E8D7C0600E84A57 /* Request.swift in Sources */,
 				FAFE54721D7BB2E800391FDD /* Hash.swift in Sources */,
-				8D45AFF61E8D739500E84A57 /* SSHVerificationTests.swift in Sources */,
+				8D45AFF61E8D739500E84A57 /* SSHHostVerificationTests.swift in Sources */,
 				FAE45B9F1E64AA4500A583AB /* Ed25519.swift in Sources */,
 				8D003DF31D90EDE30085ED21 /* Sodium.swift in Sources */,
 				8DCB60241E9442F300E1B924 /* SiloTests.swift in Sources */,

--- a/Kryptonite/AWS.swift
+++ b/Kryptonite/AWS.swift
@@ -75,7 +75,7 @@ class API {
                 
                 guard let jsonObject = (try? JSONSerialization.jsonObject(with: response.data, options: JSONSerialization.ReadingOptions.allowFragments)) as? [String:Any],
                       let semVer = jsonObject["iOS"] as? String,
-                      let version = Version(string: semVer)
+                      let version = try? Version(string: semVer)
                 else {
                     completionHandler(nil, UnknownRemoteAppVersionError())
                     return

--- a/Kryptonite/CryptoError.swift
+++ b/Kryptonite/CryptoError.swift
@@ -13,6 +13,7 @@ enum CryptoError : Error {
     case paramCreate
     case generate(KeyType, OSStatus?)
     case sign(KeyType, OSStatus?)
+    case unsupportedSignatureDigestAlgorithmType
     case encrypt
     case decrypt
     case export(OSStatus?)

--- a/Kryptonite/Ed25519.swift
+++ b/Kryptonite/Ed25519.swift
@@ -166,7 +166,10 @@ class Ed25519KeyPair:KeyPair {
         return true
     }
     
-    func sign(data:Data) throws -> Data {
+    func sign(data:Data, digestType:DigestType) throws -> Data {
+        guard digestType == .ed25519 else {
+            throw CryptoError.unsupportedSignatureDigestAlgorithmType
+        }
         guard let sig = try KRSodium.shared().sign.signature(message: data, secretKey: self.edKeyPair.secretKey) else {
             throw CryptoError.sign(.Ed25519, nil)
         }

--- a/Kryptonite/Ed25519.swift
+++ b/Kryptonite/Ed25519.swift
@@ -183,7 +183,10 @@ extension Sign.PublicKey:PublicKey {
         return KeyType.Ed25519
     }
     
-    func verify(_ message:Data, signature:Data) throws -> Bool {
+    func verify(_ message:Data, signature:Data, digestType:DigestType) throws -> Bool {
+        guard digestType == .ed25519 else {
+            throw CryptoError.unsupportedSignatureDigestAlgorithmType
+        }
         return try KRSodium.shared().sign.verify(message: message, publicKey: self, signature: signature)
     }
     func export() throws -> Data {

--- a/Kryptonite/Hash.swift
+++ b/Kryptonite/Hash.swift
@@ -9,6 +9,15 @@
 import Foundation
 import CommonCrypto
 extension Data {
+    var SHA512:Data {
+        var dataBytes = self.withUnsafeBytes {
+            [UInt8](UnsafeBufferPointer(start: $0, count: self.count))
+        }
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
+        CC_SHA512(&dataBytes, CC_LONG(self.count), &hash)
+        
+        return Data(bytes: hash)
+    }
     var SHA256:Data {
         var dataBytes = self.withUnsafeBytes {
             [UInt8](UnsafeBufferPointer(start: $0, count: self.count))

--- a/Kryptonite/Info.plist
+++ b/Kryptonite/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Kryptonite/KeyPair.swift
+++ b/Kryptonite/KeyPair.swift
@@ -25,6 +25,13 @@ enum KeyType:String {
     case Ed25519 = "ed25519"
 }
 
+enum DigestType {
+    case ed25519
+    case sha1
+    case sha256
+    case sha512
+}
+
 let KeychainAccessiblity = String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
 
 protocol PublicKey {
@@ -39,14 +46,13 @@ protocol PrivateKey {}
 protocol KeyPair {
     var publicKey:PublicKey { get }
     var privateKey:PrivateKey { get }
-        
+    
     static func loadOrGenerate(_ tag: String) throws -> KeyPair
     static func load(_ tag: String) throws -> KeyPair?
     static func generate(_ tag: String) throws -> KeyPair
     static func destroy(_ tag: String) throws -> Bool
     
-    func sign(data:Data) throws -> Data
-
+    func sign(data:Data, digestType:DigestType) throws -> Data
 }
 
 

--- a/Kryptonite/KeyPair.swift
+++ b/Kryptonite/KeyPair.swift
@@ -36,7 +36,7 @@ let KeychainAccessiblity = String(kSecAttrAccessibleAfterFirstUnlockThisDeviceOn
 
 protocol PublicKey {
     var type:KeyType {  get }
-    func verify(_ message:Data, signature:Data) throws -> Bool
+    func verify(_ message:Data, signature:Data, digestType:DigestType) throws -> Bool
     func export() throws -> Data
     static func importFrom(_ tag:String, publicKeyRaw:Data) throws -> PublicKey
 }

--- a/Kryptonite/Pairing.swift
+++ b/Kryptonite/Pairing.swift
@@ -51,7 +51,7 @@ struct Pairing:JsonReadable {
         
         var version:Version?
         if let v:String = try? json ~> "v" {
-            version = Version(string: v)
+            version = try Version(string: v)
         }
         
         try self.init(name: json ~> "n", workstationPublicKey: workstationPublicKey, version:version)

--- a/Kryptonite/Properties.swift
+++ b/Kryptonite/Properties.swift
@@ -11,7 +11,7 @@ import Foundation
 struct Properties {
     
     //MARK: Version
-    static let currentVersion = Version(major: 2, minor: 0, patch: 2)
+    static let currentVersion = Version(major: 2, minor: 1, patch: 0)
     static let appVersionURL = "https://s3.amazonaws.com/kr-versions/versions"
     
     static let updateCheckIntervalForeground = TimeSeconds.hour.multiplied(by: 6)

--- a/Kryptonite/Request.swift
+++ b/Kryptonite/Request.swift
@@ -14,12 +14,12 @@ struct Request:Jsonable {
     var id:String
     var unixSeconds:Int
     var sendACK:Bool
-    var version:Version?
+    var version:Version
     var sign:SignRequest?
     var me:MeRequest?
     var unpair:UnpairRequest?
 
-    init(id: String, unixSeconds: Int, sendACK: Bool, version: Version? = nil, sign: SignRequest? = nil, me: MeRequest? = nil, unpair: UnpairRequest? = nil) {
+    init(id: String, unixSeconds: Int, sendACK: Bool, version: Version, sign: SignRequest? = nil, me: MeRequest? = nil, unpair: UnpairRequest? = nil) {
         self.id = id
         self.unixSeconds = unixSeconds
         self.sendACK = sendACK
@@ -27,12 +27,14 @@ struct Request:Jsonable {
         self.sign = sign
         self.me = me
         self.unpair = unpair
+        
     }
     
     init(json: Object) throws {
         self.id = try json ~> "request_id"
         self.unixSeconds = try json ~> "unix_seconds"
         self.sendACK = (try? json ~> "a") ?? false
+        self.version = try Version(string: json ~> "v")
 
         if let json:Object = try? json ~> "sign_request" {
             self.sign = try SignRequest(json: json)
@@ -44,10 +46,6 @@ struct Request:Jsonable {
 
         if let json:Object = try? json ~> "unpair_request" {
             self.unpair = try UnpairRequest(json: json)
-        }
-
-        if let verString:String = try? json ~> "v" {
-            self.version = Version(string: verString)
         }
     }
     

--- a/Kryptonite/Request.swift
+++ b/Kryptonite/Request.swift
@@ -54,6 +54,7 @@ struct Request:Jsonable {
         json["request_id"] = id
         json["unix_seconds"] = unixSeconds
         json["a"] = sendACK
+        json["v"] = version.string
 
         if let s = sign {
             json["sign_request"] = s.object

--- a/Kryptonite/Response.swift
+++ b/Kryptonite/Response.swift
@@ -36,7 +36,7 @@ final class Response:Jsonable {
     init(json: Object) throws {
         self.requestID = try json ~> "request_id"
         self.snsEndpointARN = try json ~> "sns_endpoint_arn"
-        self.version = Version(string: try json ~> "v")
+        self.version = try Version(string: json ~> "v")
 
         if let approvedUntil:Int = try? json ~> "approved_until" {
             self.approvedUntil = approvedUntil

--- a/Kryptonite/SSHFormat.swift
+++ b/Kryptonite/SSHFormat.swift
@@ -1,5 +1,5 @@
 //
-//  SSHKeyFormat.swift
+//  SSHFormat.swift
 //  Kryptonite
 //
 //  Created by Alex Grinman on 8/28/16.
@@ -130,15 +130,33 @@ extension Sign.PublicKey:SSHPublicKey {
     }
 }
 
+// MARK: SSH Digest Type
+struct UnsupportedSSHDigestAlgorithm:Error {}
+extension DigestType {
+    init(algorithmName:String) throws {
+        switch algorithmName {
+            case KeyType.RSA.sshHeader():
+                self = .sha1
+            case "rsa-sha2-256":
+                self = .sha256
+            case "rsa-sha2-512":
+                self = .sha512
+            case KeyType.Ed25519.sshHeader():
+                self = .ed25519
+            default:
+                throw UnsupportedSSHDigestAlgorithm()
+        }
+    }
+}
 
 // MARK: SSH Signature Format 
 extension KeyPair {
-    func signAppendingSSHWirePubkeyToPayload(data:Data) throws -> String {
+    func signAppendingSSHWirePubkeyToPayload(data:Data, digestType:DigestType) throws -> String {
         var dataClone = Data(data)
         let pubkeyWire = try publicKey.wireFormat()
         dataClone.append(contentsOf: pubkeyWire.bigEndianByteSize())
         dataClone.append(pubkeyWire)
-        return try sign(data: dataClone).toBase64()
+        return try sign(data: dataClone, digestType: digestType).toBase64()
     }
     
 }

--- a/Kryptonite/SSHUtil.swift
+++ b/Kryptonite/SSHUtil.swift
@@ -1,0 +1,71 @@
+//
+//  SSHUtil.swift
+//  Kryptonite
+//
+//  Created by Alex Grinman on 5/9/17.
+//  Copyright © 2017 KryptCo. All rights reserved.
+//
+
+import Foundation
+
+typealias SSHMessage = Data
+struct SSHMessageParsingError:Error {}
+
+extension SSHMessage {
+    
+    mutating func popByte() throws -> UInt8 {
+        guard self.count >= 1 else {
+            throw SSHMessageParsingError()
+        }
+        
+        let len = 1
+        let start = 0
+        let end = start + len
+        
+        let out = self.subdata(in: start ..< end ).bytes[0]
+        
+        if self.count > end {
+            self = self.subdata(in: end ..< self.count)
+        } else {
+            self = Data()
+        }
+        
+        return out
+    }
+    
+    mutating func popBool() throws -> Bool {
+        return (try self.popByte() == 1) ? true : false
+    }
+
+    
+    mutating func popData() throws -> Data {
+        guard self.count >= 4 else {
+            throw SSHMessageParsingError()
+        }
+        
+        let lenBigEndianBytes = self.subdata(in: 0 ..< 4)
+        guard let len = UInt32(exactly: Int32(bigEndianBytes: [UInt8](lenBigEndianBytes))) else {
+            throw SSHMessageParsingError()
+        }
+        let start = 4
+        let end = start + Int(len)
+        
+        let out = self.subdata(in: start ..< end )
+        
+        if self.count > end {
+            self = self.subdata(in: end ..< self.count)
+        } else {
+            self = Data()
+        }
+        
+        return out
+    }
+    
+    mutating func popString() throws -> String {
+        guard let out = String(bytes: try self.popData(), encoding: .utf8) else {
+            throw SSHMessageParsingError()
+        }
+        
+        return out
+    }
+}

--- a/Kryptonite/SSHUtil.swift
+++ b/Kryptonite/SSHUtil.swift
@@ -18,14 +18,10 @@ extension SSHMessage {
             throw SSHMessageParsingError()
         }
         
-        let len = 1
-        let start = 0
-        let end = start + len
+        let out = self.bytes[0]
         
-        let out = self.subdata(in: start ..< end ).bytes[0]
-        
-        if self.count > end {
-            self = self.subdata(in: end ..< self.count)
+        if self.count > 1 {
+            self = self.subdata(in: 1 ..< self.count)
         } else {
             self = Data()
         }
@@ -50,6 +46,9 @@ extension SSHMessage {
         let start = 4
         let end = start + Int(len)
         
+        guard self.count >= end else {
+            throw SSHMessageParsingError()
+        }
         let out = self.subdata(in: start ..< end )
         
         if self.count > end {

--- a/Kryptonite/Session.swift
+++ b/Kryptonite/Session.swift
@@ -40,7 +40,7 @@ struct Session:Jsonable {
 
         var version:Version?
         if let verString:String = try? json ~> "version" {
-            version = Version(string: verString)
+            version = try Version(string: verString)
         }
 
         pairing = try Pairing(name: json ~> "name", workstationPublicKey: workstationPublicKey, keyPair: Box.KeyPair(publicKey: publicKey, secretKey: privateKey), version: version)

--- a/Kryptonite/Silo.swift
+++ b/Kryptonite/Silo.swift
@@ -187,7 +187,7 @@ class Silo {
                     }
                     
                     // only place where signature should occur
-                    sig = try kp.keyPair.signAppendingSSHWirePubkeyToPayload(data: signRequest.data, digestType: signRequest.digestType)
+                    sig = try kp.keyPair.signAppendingSSHWirePubkeyToPayload(data: signRequest.data, digestType: signRequest.digestType.based(on: request.version))
                     
                     LogManager.shared.save(theLog: SignatureLog(session: session.id, hostAuth: signRequest.hostAuth, signature: sig ?? "<err>", displayName: signRequest.display), deviceName: session.pairing.name)
                 } else {

--- a/Kryptonite/Silo.swift
+++ b/Kryptonite/Silo.swift
@@ -187,7 +187,7 @@ class Silo {
                     }
                     
                     // only place where signature should occur
-                    sig = try kp.keyPair.signAppendingSSHWirePubkeyToPayload(data: signRequest.data)
+                    sig = try kp.keyPair.signAppendingSSHWirePubkeyToPayload(data: signRequest.data, digestType: signRequest.digestType)
                     
                     LogManager.shared.save(theLog: SignatureLog(session: session.id, hostAuth: signRequest.hostAuth, signature: sig ?? "<err>", displayName: signRequest.display), deviceName: session.pairing.name)
                 } else {

--- a/Kryptonite/Version.swift
+++ b/Kryptonite/Version.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+struct InvalidVersionStringError:Error{}
+
 class Version: Comparable {
     let major:UInt
     let minor:UInt
@@ -26,18 +28,18 @@ class Version: Comparable {
     }
     
     //MARK: To/From String
-    init?(string:String) {
+    init(string:String) throws {
         let versionComponents = string.components(separatedBy: ".")
         
         guard versionComponents.count == 3 else {
-            return nil
+            throw InvalidVersionStringError()
         }
         
         guard   let major = UInt(versionComponents[0]),
                 let minor = UInt(versionComponents[1]),
                 let patch = UInt(versionComponents[2])
         else {
-            return nil
+            throw InvalidVersionStringError()
         }
         
         self.major = major

--- a/LastCommand/Info.plist
+++ b/LastCommand/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>522</string>
 	<key>NSExtension</key>

--- a/Notify/Info.plist
+++ b/Notify/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.2</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>522</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
RSA hash function is picked from the SSH_USERAUTH message. This fixes the possible error (and weakness) of defaulting to sha1 which openssh servers seem to still accept.