### PR TITLE
Increase clock skew tolerance and make session activity update on success only

### DIFF
--- a/Kryptonite/Properties.swift
+++ b/Kryptonite/Properties.swift
@@ -57,7 +57,7 @@ struct Properties {
     }
 
     static let communicationActivityTimeout = 60.0
-    static let requestTimeTolerance = 120.0
+    static let requestTimeTolerance = TimeSeconds.minute.multiplied(by: 15)
 
     init() {}
     

--- a/Kryptonite/Silo.swift
+++ b/Kryptonite/Silo.swift
@@ -227,7 +227,7 @@ class Silo {
         
         let responseData = try response.jsonData() as NSData
         
-        requestCache?.setObject(responseData, forKey: CacheKey(session, request), expires: .seconds(300))
+        requestCache?.setObject(responseData, forKey: CacheKey(session, request), expires: .seconds(Properties.requestTimeTolerance * 2))
         
         return response
 

--- a/Kryptonite/TransportControl.swift
+++ b/Kryptonite/TransportControl.swift
@@ -77,6 +77,8 @@ class TransportControl {
     
     //MARK: Handle Incoming Requests
     func handle(medium:CommunicationMedium, with request:Request, for session:Session, completionHandler: (()->Void)? = nil) throws {
+        try Silo.shared.handle(request: request, session: session, communicationMedium: medium, completionHandler: completionHandler)
+
         mutex.lock()
         
         log("Handle Called: \(sessionActivity.count)")
@@ -92,8 +94,6 @@ class TransportControl {
         }
         
         mutex.unlock()
-
-        try Silo.shared.handle(request: request, session: session, communicationMedium: medium, completionHandler: completionHandler)
     }
     
     //MARK: Send Outgoing Requests


### PR DESCRIPTION
This should fix the inexplicable pairing failures we have seen from some users. With the previous behavior, a clock skew of only 2 minutes on a machine would result in the phone showing pairing success but failing silently, leaving `kr` to timeout.

15 minutes should be enough to cover most users' clock skew, and the update to `kr` will warn and tell users how to sync their clocks if their drift violates AWS' tolerance (I believe 10-15 minutes).

Eventually we should add a clock skew check to the pairing process, but I'll create a separate issue for this.