### PR TITLE
Compile libsodium from source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "swift-sodium"]
 	path = swift-sodium
-	url  = https://github.com/kryptco/swift-sodium
+	url  = git@github.com:kryptco/swift-sodium.git
 [submodule "AwesomeCache"]
 	path = AwesomeCache
 	url = git@github.com:KryptCo/AwesomeCache.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: swift
 xcode_project: Kryptonite.xcodeproj
 xcode_scheme: Debug
-osx_image: xcode9.0
+osx_image: xcode9
 git:
     submodules: false
 # travis work around

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ osx_image: xcode8.3
 git:
     submodules: false
 before_install:
-  # pin github.com public key for travis
-  - echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
+  - echo "[url \"https://github.com\"]
+    insteadOf = git://github.com
+    insteadOf = git@github.com" >> ~/.gitconfig
+  - sed -i '' -e 's/git@github.com:/https:\/\/github.com\//' .gitmodules
   - git submodule update --init --recursive
 before_script:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ osx_image: xcode8.3
 git:
     submodules: false
 before_install:
-  - sed -i '' -e 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  # pin github.com public key for travis
+  - echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
   - git submodule update --init --recursive
 before_script:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: swift
 xcode_project: Kryptonite.xcodeproj
 xcode_scheme: Debug
-osx_image: xcode8.3
+osx_image: xcode9.0
 git:
     submodules: false
+# travis work around
 before_install:
-  - echo "[url \"https://github.com\"]
-    insteadOf = git://github.com
-    insteadOf = git@github.com" >> ~/.gitconfig
   - sed -i '' -e 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive
+  - git submodule update --init
+  - sed -i '' -e 's/git@github.com:/https:\/\/github.com\//' swift-sodium/.gitmodules
+  - cd swift-sodium/ && git submodule update --init && cd ..
 before_script:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y
   - export PATH=$PATH:$HOME/.cargo/bin/

--- a/KryptoTests/PairingTests.swift
+++ b/KryptoTests/PairingTests.swift
@@ -26,7 +26,7 @@ class PairingTests: XCTestCase {
     
     func testCreatePairing() {
         do {
-            let pk = try KRSodium.shared().box.keyPair()!.publicKey
+            let pk = KRSodium.shared().box.keyPair()!.publicKey
             let _ = try Pairing(name: "test", workstationPublicKey: pk)
         } catch {
             XCTFail("error: \(error)")
@@ -36,14 +36,14 @@ class PairingTests: XCTestCase {
     func testWrapPublicKey() {
         
         do {
-            let kp = try KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.shared().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let wrappedPub = try pairing.keyPair.publicKey.wrap(to: kp.publicKey)
             
             // unwrapp pub
             
-            let unwrapped = try KRSodium.shared().box.open(anonymousCipherText: wrappedPub, recipientPublicKey: kp.publicKey, recipientSecretKey: kp.secretKey)!
+            let unwrapped = KRSodium.shared().box.open(anonymousCipherText: wrappedPub, recipientPublicKey: kp.publicKey, recipientSecretKey: kp.secretKey)!
             
             // ensure unwrapped == pairing.publicKey
             
@@ -60,14 +60,14 @@ class PairingTests: XCTestCase {
         
         do {
             
-            let kp = try KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.shared().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let dataStruct = TestStruct(p1: "hello", p2: "world")
             
             let sealed = try dataStruct.seal(to: pairing)
     
-            let unsealed = try KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.keyPair.publicKey, recipientSecretKey: kp.secretKey)!
+            let unsealed = KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.keyPair.publicKey, recipientSecretKey: kp.secretKey)!
             
             let dataStructUnsealed = try TestStruct(jsonData: unsealed)
             // ensure sealed == unsealed
@@ -85,12 +85,12 @@ class PairingTests: XCTestCase {
         
         do {
             
-            let kp = try KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.shared().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let dataStruct = TestStruct(p1: "hello", p2: "world")
             
-            let sealed:Data = try KRSodium.shared().box.seal(message: dataStruct.jsonData(), recipientPublicKey: pairing.keyPair.publicKey, senderSecretKey: kp.secretKey)!
+            let sealed:Data = KRSodium.shared().box.seal(message: try dataStruct.jsonData(), recipientPublicKey: pairing.keyPair.publicKey, senderSecretKey: kp.secretKey)!
             
             let unsealed = try TestStruct(from: pairing, sealed: sealed)
             

--- a/KryptoTests/PairingTests.swift
+++ b/KryptoTests/PairingTests.swift
@@ -26,7 +26,7 @@ class PairingTests: XCTestCase {
     
     func testCreatePairing() {
         do {
-            let pk = KRSodium.shared().box.keyPair()!.publicKey
+            let pk = KRSodium.instance().box.keyPair()!.publicKey
             let _ = try Pairing(name: "test", workstationPublicKey: pk)
         } catch {
             XCTFail("error: \(error)")
@@ -36,14 +36,14 @@ class PairingTests: XCTestCase {
     func testWrapPublicKey() {
         
         do {
-            let kp = KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.instance().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let wrappedPub = try pairing.keyPair.publicKey.wrap(to: kp.publicKey)
             
             // unwrapp pub
             
-            let unwrapped = KRSodium.shared().box.open(anonymousCipherText: wrappedPub, recipientPublicKey: kp.publicKey, recipientSecretKey: kp.secretKey)!
+            let unwrapped = KRSodium.instance().box.open(anonymousCipherText: wrappedPub, recipientPublicKey: kp.publicKey, recipientSecretKey: kp.secretKey)!
             
             // ensure unwrapped == pairing.publicKey
             
@@ -60,14 +60,14 @@ class PairingTests: XCTestCase {
         
         do {
             
-            let kp = KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.instance().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let dataStruct = TestStruct(p1: "hello", p2: "world")
             
             let sealed = try dataStruct.seal(to: pairing)
     
-            let unsealed = KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.keyPair.publicKey, recipientSecretKey: kp.secretKey)!
+            let unsealed = KRSodium.instance().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.keyPair.publicKey, recipientSecretKey: kp.secretKey)!
             
             let dataStructUnsealed = try TestStruct(jsonData: unsealed)
             // ensure sealed == unsealed
@@ -85,12 +85,12 @@ class PairingTests: XCTestCase {
         
         do {
             
-            let kp = KRSodium.shared().box.keyPair()!
+            let kp = KRSodium.instance().box.keyPair()!
             let pairing = try Pairing(name: "test", workstationPublicKey: kp.publicKey)
             
             let dataStruct = TestStruct(p1: "hello", p2: "world")
             
-            let sealed:Data = KRSodium.shared().box.seal(message: try dataStruct.jsonData(), recipientPublicKey: pairing.keyPair.publicKey, senderSecretKey: kp.secretKey)!
+            let sealed:Data = KRSodium.instance().box.seal(message: try dataStruct.jsonData(), recipientPublicKey: pairing.keyPair.publicKey, senderSecretKey: kp.secretKey)!
             
             let unsealed = try TestStruct(from: pairing, sealed: sealed)
             

--- a/KryptoTests/SiloTests.swift
+++ b/KryptoTests/SiloTests.swift
@@ -25,7 +25,7 @@ class SiloTests: XCTestCase {
 
     func testNeverPaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
 
@@ -42,7 +42,7 @@ class SiloTests: XCTestCase {
 
     func testPaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -56,7 +56,7 @@ class SiloTests: XCTestCase {
 
     func testUnpaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -86,7 +86,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -112,7 +112,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 - Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -138,7 +138,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 + Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -164,7 +164,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -182,7 +182,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -202,7 +202,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: randomFp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -229,7 +229,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.shared().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
             
             SessionManager.shared.add(session: session, temporary: true)

--- a/KryptoTests/SiloTests.swift
+++ b/KryptoTests/SiloTests.swift
@@ -25,7 +25,7 @@ class SiloTests: XCTestCase {
 
     func testNeverPaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
 
@@ -42,7 +42,7 @@ class SiloTests: XCTestCase {
 
     func testPaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -56,7 +56,7 @@ class SiloTests: XCTestCase {
 
     func testUnpaired() {
         do {
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -86,7 +86,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -112,7 +112,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 - Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -138,7 +138,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970 + Properties.requestTimeTolerance * 3), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -164,7 +164,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -182,7 +182,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -202,7 +202,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: randomFp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
 
             SessionManager.shared.add(session: session, temporary: true)
@@ -229,7 +229,7 @@ class SiloTests: XCTestCase {
             let data = try "AAAAIFrZQlwF8k3UCrkwZ2E0U+qGx57wehv5ABkHJStoOCc3MgAAAANnaXQAAAAOc3NoLWNvbm5lY3Rpb24AAAAJcHVibGlja2V5AQAAAAdzc2gtcnNh".fromBase64()
             let sign = try SignRequest(data: data, fingerprint: fp, hostAuth: nil)
             let request = try Request(id: Data.random(size: 16).toBase64(), unixSeconds: Int(Date().timeIntervalSince1970), sendACK: false, version: Properties.currentVersion, body: .ssh(sign))
-            let pairing = try Pairing(name: "test", workstationPublicKey: try KRSodium.instance().box.keyPair()!.publicKey)
+            let pairing = try Pairing(name: "test", workstationPublicKey: KRSodium.instance().box.keyPair()!.publicKey)
             let session = try Session(pairing: pairing)
             
             SessionManager.shared.add(session: session, temporary: true)

--- a/Kryptonite.xcodeproj/project.pbxproj
+++ b/Kryptonite.xcodeproj/project.pbxproj
@@ -561,7 +561,6 @@
 		8D45B0091E8D7D6F00E84A57 /* Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
 		8D7941671D98732600F6E32E /* NetworkProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProtocol.swift; sourceTree = "<group>"; };
 		8D83990B1E56063A0051C6BA /* HostAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HostAuth.swift; sourceTree = "<group>"; };
-		8D93CD641D9198C7008955B2 /* libsodium-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libsodium-ios.a"; path = "swift-sodium/Sodium/libsodium-ios.a"; sourceTree = "<group>"; };
 		8DB2EE381DBC18170079E468 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		8DB2EE3B1DBC54EF0079E468 /* SwiftHTTP.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftHTTP.xcodeproj; path = SwiftHTTP/SwiftHTTP.xcodeproj; sourceTree = "<group>"; };
 		8DC2639D1ED2459300BF2E17 /* CommitInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
@@ -1168,7 +1167,6 @@
 				FABA4B1A1D9C68F30057A666 /* LocalAuthentication.framework */,
 				FAC5612F1E6F676F00150FB2 /* AwesomeCache.xcodeproj */,
 				8D003DD81D90EBB10085ED21 /* Sodium.xcodeproj */,
-				8D93CD641D9198C7008955B2 /* libsodium-ios.a */,
 				8DC38BC41E6899FD007445B4 /* sshwire */,
 				FACAA4B91D8887FA000B9A01 /* CoreData.framework */,
 				FACAA4AD1D87C44D000B9A01 /* MapKit.framework */,

--- a/Kryptonite/Ed25519.swift
+++ b/Kryptonite/Ed25519.swift
@@ -83,7 +83,7 @@ class Ed25519KeyPair:KeyPair {
     }
     
     static func generate(_ tag: String) throws -> KeyPair {
-        guard let newKeypair = KRSodium.shared().sign.keyPair() else {
+        guard let newKeypair = KRSodium.instance().sign.keyPair() else {
             throw CryptoError.generate(.Ed25519, nil)
         }
         
@@ -166,7 +166,7 @@ class Ed25519KeyPair:KeyPair {
         guard digestType == .ed25519 else {
             throw CryptoError.unsupportedSignatureDigestAlgorithmType
         }
-        guard let sig = KRSodium.shared().sign.signature(message: data, secretKey: self.edKeyPair.secretKey) else {
+        guard let sig = KRSodium.instance().sign.signature(message: data, secretKey: self.edKeyPair.secretKey) else {
             throw CryptoError.sign(.Ed25519, nil)
         }
         
@@ -183,7 +183,7 @@ extension Sign.PublicKey:PublicKey {
         guard digestType == .ed25519 else {
             throw CryptoError.unsupportedSignatureDigestAlgorithmType
         }
-        return KRSodium.shared().sign.verify(message: message, publicKey: self, signature: signature)
+        return KRSodium.instance().sign.verify(message: message, publicKey: self, signature: signature)
     }
     func export() throws -> Data {
         return self as Data

--- a/Kryptonite/Ed25519.swift
+++ b/Kryptonite/Ed25519.swift
@@ -42,12 +42,12 @@ class Ed25519KeyPair:KeyPair {
     static func load(_ tag: String) throws -> KeyPair? {
         
         // load the private key
-        let privParams = [String(kSecClass): kSecClassGenericPassword,
+        let privParams:[String : Any] = [String(kSecClass): kSecClassGenericPassword,
                       String(kSecAttrService): Ed25519KeychainService,
                       String(kSecAttrAccount): KeyIdentifier.Private.tag(tag),
                       String(kSecReturnData): kCFBooleanTrue,
                       String(kSecMatchLimit): kSecMatchLimitOne,
-                      String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                      String(kSecAttrAccessible): KeychainAccessiblity]
         
         var privObject:AnyObject?
         let privStatus = SecItemCopyMatching(privParams as CFDictionary, &privObject)
@@ -61,12 +61,12 @@ class Ed25519KeyPair:KeyPair {
         }
         
         // load the public key
-        let pubParams = [String(kSecClass): kSecClassGenericPassword,
+        let pubParams:[String : Any] = [String(kSecClass): kSecClassGenericPassword,
                           String(kSecAttrService): Ed25519KeychainService,
                           String(kSecAttrAccount): KeyIdentifier.Public.tag(tag),
                           String(kSecReturnData): kCFBooleanTrue,
                           String(kSecMatchLimit): kSecMatchLimitOne,
-                          String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                          String(kSecAttrAccessible): KeychainAccessiblity]
         
         var pubObject:AnyObject?
         let pubStatus = SecItemCopyMatching(pubParams as CFDictionary, &pubObject)
@@ -83,7 +83,7 @@ class Ed25519KeyPair:KeyPair {
     }
     
     static func generate(_ tag: String) throws -> KeyPair {
-        guard let newKeypair = try KRSodium.shared().sign.keyPair() else {
+        guard let newKeypair = KRSodium.shared().sign.keyPair() else {
             throw CryptoError.generate(.Ed25519, nil)
         }
         
@@ -91,11 +91,11 @@ class Ed25519KeyPair:KeyPair {
         let pub = newKeypair.publicKey
         
         // save the private key
-        let privParams = [String(kSecClass): kSecClassGenericPassword,
+        let privParams:[String : Any] = [String(kSecClass): kSecClassGenericPassword,
                           String(kSecAttrService): Ed25519KeychainService,
                           String(kSecAttrAccount): KeyIdentifier.Private.tag(tag),
                           String(kSecValueData): priv,
-                          String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                          String(kSecAttrAccessible): KeychainAccessiblity]
         
         let privDeleteStatus = SecItemDelete(privParams as CFDictionary)
         guard privDeleteStatus == errSecItemNotFound || privDeleteStatus.isSuccess()
@@ -110,11 +110,11 @@ class Ed25519KeyPair:KeyPair {
         }
 
         // save the public key
-        let pubParams = [String(kSecClass): kSecClassGenericPassword,
+        let pubParams:[String : Any] = [String(kSecClass): kSecClassGenericPassword,
                           String(kSecAttrService): Ed25519KeychainService,
                           String(kSecAttrAccount): KeyIdentifier.Public.tag(tag),
                           String(kSecValueData): pub,
-                          String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                          String(kSecAttrAccessible): KeychainAccessiblity]
         
         let pubDeleteStatus = SecItemDelete(pubParams as CFDictionary)
         guard pubDeleteStatus == errSecItemNotFound || pubDeleteStatus.isSuccess()
@@ -136,10 +136,10 @@ class Ed25519KeyPair:KeyPair {
     static func destroy(_ tag: String) throws {
         
         // destroy the private key
-        let privParams = [String(kSecClass): kSecClassGenericPassword,
+        let privParams: [String : Any] = [String(kSecClass): kSecClassGenericPassword,
                           String(kSecAttrService): Ed25519KeychainService,
                           String(kSecAttrAccount): KeyIdentifier.Private.tag(tag),
-                          String(kSecAttrAccessible):KeychainAccessiblity] as [String : Any]
+                          String(kSecAttrAccessible):KeychainAccessiblity]
         
         let privDeleteStatus = SecItemDelete(privParams as CFDictionary)
         
@@ -149,10 +149,10 @@ class Ed25519KeyPair:KeyPair {
         }
         
         // destroy the public key
-        let pubParams = [String(kSecClass): kSecClassGenericPassword,
+        let pubParams: [String : Any] = [String(kSecClass): kSecClassGenericPassword,
                           String(kSecAttrService): Ed25519KeychainService,
                           String(kSecAttrAccount): KeyIdentifier.Public.tag(tag),
-                          String(kSecAttrAccessible):KeychainAccessiblity] as [String : Any]
+                          String(kSecAttrAccessible):KeychainAccessiblity]
         
         let pubDeleteStatus = SecItemDelete(pubParams as CFDictionary)
         
@@ -166,7 +166,7 @@ class Ed25519KeyPair:KeyPair {
         guard digestType == .ed25519 else {
             throw CryptoError.unsupportedSignatureDigestAlgorithmType
         }
-        guard let sig = try KRSodium.shared().sign.signature(message: data, secretKey: self.edKeyPair.secretKey) else {
+        guard let sig = KRSodium.shared().sign.signature(message: data, secretKey: self.edKeyPair.secretKey) else {
             throw CryptoError.sign(.Ed25519, nil)
         }
         
@@ -183,7 +183,7 @@ extension Sign.PublicKey:PublicKey {
         guard digestType == .ed25519 else {
             throw CryptoError.unsupportedSignatureDigestAlgorithmType
         }
-        return try KRSodium.shared().sign.verify(message: message, publicKey: self, signature: signature)
+        return KRSodium.shared().sign.verify(message: message, publicKey: self, signature: signature)
     }
     func export() throws -> Data {
         return self as Data

--- a/Kryptonite/JSON+Seal.swift
+++ b/Kryptonite/JSON+Seal.swift
@@ -15,7 +15,7 @@ typealias Sealed = Data
 extension JsonWritable {
     func seal(to pairing:Pairing) throws -> Sealed {
         
-        let sealedResult:Data? = try KRSodium.shared().box.seal(message: self.jsonData(), recipientPublicKey: pairing.workstationPublicKey, senderSecretKey: pairing.keyPair.secretKey)
+        let sealedResult:Data? = try KRSodium.instance().box.seal(message: self.jsonData(), recipientPublicKey: pairing.workstationPublicKey, senderSecretKey: pairing.keyPair.secretKey)
         
         guard let sealed = sealedResult else {
             throw CryptoError.encrypt
@@ -32,7 +32,7 @@ extension JsonReadable {
     }
 
     init(from pairing:Pairing, sealed:Sealed) throws {
-        let unsealedResult = KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.workstationPublicKey, recipientSecretKey: pairing.keyPair.secretKey)
+        let unsealedResult = KRSodium.instance().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.workstationPublicKey, recipientSecretKey: pairing.keyPair.secretKey)
         
         guard let unsealed = unsealedResult else {
             throw CryptoError.decrypt

--- a/Kryptonite/JSON+Seal.swift
+++ b/Kryptonite/JSON+Seal.swift
@@ -32,7 +32,7 @@ extension JsonReadable {
     }
 
     init(from pairing:Pairing, sealed:Sealed) throws {
-        let unsealedResult = try KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.workstationPublicKey, recipientSecretKey: pairing.keyPair.secretKey)
+        let unsealedResult = KRSodium.shared().box.open(nonceAndAuthenticatedCipherText: sealed, senderPublicKey: pairing.workstationPublicKey, recipientSecretKey: pairing.keyPair.secretKey)
         
         guard let unsealed = unsealedResult else {
             throw CryptoError.decrypt

--- a/Kryptonite/KeychainStorage.swift
+++ b/Kryptonite/KeychainStorage.swift
@@ -30,11 +30,11 @@ class KeychainStorage {
         mutex.lock()
         defer { self.mutex.unlock() }
         
-        let params = [String(kSecClass): kSecClassGenericPassword,
+        let params: [String : Any] = [String(kSecClass): kSecClassGenericPassword,
                       String(kSecAttrService): service,
                       String(kSecAttrAccount): key,
                       String(kSecValueData): data,
-                      String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                      String(kSecAttrAccessible): KeychainAccessiblity]
         
         let _ = SecItemDelete(params as CFDictionary)
         
@@ -54,12 +54,12 @@ class KeychainStorage {
         mutex.lock()
         defer { self.mutex.unlock() }
 
-        let params = [String(kSecClass): kSecClassGenericPassword,
+        let params:[String : Any] = [String(kSecClass): kSecClassGenericPassword,
                       String(kSecAttrService): service,
                       String(kSecAttrAccount): key,
                       String(kSecReturnData): kCFBooleanTrue,
                       String(kSecMatchLimit): kSecMatchLimitOne,
-                      String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                      String(kSecAttrAccessible): KeychainAccessiblity]
         
         var object:AnyObject?
         let status = SecItemCopyMatching(params as CFDictionary, &object)
@@ -84,9 +84,9 @@ class KeychainStorage {
         mutex.lock()
         defer { self.mutex.unlock() }
 
-        let params = [String(kSecClass): kSecClassGenericPassword,
+        let params: [String : Any] = [String(kSecClass): kSecClassGenericPassword,
                       String(kSecAttrService): service,
-                      String(kSecAttrAccount): key] as [String : Any]
+                      String(kSecAttrAccount): key]
         
         let status = SecItemDelete(params as CFDictionary)
         

--- a/Kryptonite/Pairing.swift
+++ b/Kryptonite/Pairing.swift
@@ -30,7 +30,7 @@ struct Pairing:JsonReadable {
 
     
     init(name: String, workstationPublicKey:Box.PublicKey, version:Version? = nil) throws {
-        guard let keyPair = try KRSodium.shared().box.keyPair() else {
+        guard let keyPair = KRSodium.shared().box.keyPair() else {
             throw CryptoError.generate(KeyType.Ed25519, nil)
         }
         

--- a/Kryptonite/Pairing.swift
+++ b/Kryptonite/Pairing.swift
@@ -30,7 +30,7 @@ struct Pairing:JsonReadable {
 
     
     init(name: String, workstationPublicKey:Box.PublicKey, version:Version? = nil) throws {
-        guard let keyPair = KRSodium.shared().box.keyPair() else {
+        guard let keyPair = KRSodium.instance().box.keyPair() else {
             throw CryptoError.generate(KeyType.Ed25519, nil)
         }
         

--- a/Kryptonite/RSAKeyPair.swift
+++ b/Kryptonite/RSAKeyPair.swift
@@ -49,12 +49,12 @@ class RSAKeyPair:KeyPair {
         // get the private key
         let privTag = KeyIdentifier.Private.tag(tag)
         
-        var params = [String(kSecReturnRef): kCFBooleanTrue,
+        var params:[String : Any] = [String(kSecReturnRef): kCFBooleanTrue,
                       String(kSecClass): kSecClassKey,
                       String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
                       String(kSecAttrApplicationTag): privTag,
                       String(kSecAttrAccessible):KeychainAccessiblity,
-                      ] as [String : Any]
+                      ]
         
         
         var privKeyObject:AnyObject?
@@ -77,7 +77,7 @@ class RSAKeyPair:KeyPair {
                   String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
                   String(kSecAttrApplicationTag): pubTag,
                   String(kSecAttrAccessible):KeychainAccessiblity,
-                  ] as [String : Any]
+                  ]
         
         var pubKeyObject:AnyObject?
         status = SecItemCopyMatching(params as CFDictionary, &pubKeyObject)
@@ -120,12 +120,12 @@ class RSAKeyPair:KeyPair {
         // save public key ref
         
         let pubTag = KeyIdentifier.Public.tag(tag)
-        var pubParams = [String(kSecReturnRef): kCFBooleanTrue,
+        var pubParams:[String : Any] = [String(kSecReturnRef): kCFBooleanTrue,
                          String(kSecClass): kSecClassKey,
                          String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
                          String(kSecAttrApplicationTag): pubTag,
                          String(kSecAttrAccessible):KeychainAccessiblity,
-                         ] as [String : Any]
+                         ]
         
         pubParams[String(kSecAttrKeyClass)] = kSecAttrKeyClassPublic
         pubParams[String(kSecValueRef)] = pub
@@ -152,10 +152,10 @@ class RSAKeyPair:KeyPair {
         // delete the public key
         let pubTag = KeyIdentifier.Public.tag(tag)
         
-        var params = [String(kSecClass): kSecClassKey,
+        var params: [String : Any] = [String(kSecClass): kSecClassKey,
                       String(kSecAttrApplicationTag): pubTag,
                       String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
-                      String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                      String(kSecAttrAccessible): KeychainAccessiblity]
         
         params[String(kSecAttrKeyClass)] = kSecAttrKeyClassPublic
         params[String(kSecAttrIsPermanent)] = kCFBooleanTrue
@@ -174,12 +174,12 @@ class RSAKeyPair:KeyPair {
         // delete the private key
         let privTag = KeyIdentifier.Private.tag(tag)
         
-        let params = [String(kSecReturnRef): kCFBooleanTrue,
+        let params: [String : Any] = [String(kSecReturnRef): kCFBooleanTrue,
                       String(kSecClass): kSecClassKey,
                       String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
                       String(kSecAttrApplicationTag): privTag,
                       String(kSecAttrAccessible):KeychainAccessiblity,
-                      ] as [String : Any]
+                      ]
         
         
         let status = SecItemDelete(params as CFDictionary)
@@ -297,9 +297,9 @@ struct RSAPublicKey:PublicKey {
     
     func export() throws -> Data {
         
-        var params = [String(kSecReturnData): kCFBooleanTrue,
+        var params: [String : Any] = [String(kSecReturnData): kCFBooleanTrue,
                       String(kSecClass): kSecClassKey,
-                      String(kSecValueRef): key] as [String : Any]
+                      String(kSecValueRef): key]
         
         var publicKeyObject:AnyObject?
         var status = SecItemCopyMatching(params as CFDictionary, &publicKeyObject)
@@ -327,10 +327,10 @@ struct RSAPublicKey:PublicKey {
         
         let pubTag = KeyIdentifier.Public.tag(tag)
         
-        var params = [String(kSecClass): kSecClassKey,
+        var params: [String : Any] = [String(kSecClass): kSecClassKey,
                       String(kSecAttrApplicationTag): pubTag,
                       String(kSecAttrKeyType): kSecAttrKeyTypeRSA,
-                      String(kSecAttrAccessible): KeychainAccessiblity] as [String : Any]
+                      String(kSecAttrAccessible): KeychainAccessiblity]
         
         params[String(kSecAttrKeyClass)] = kSecAttrKeyClassPublic
         params[String(kSecValueData)] = publicKeyRaw

--- a/Kryptonite/Session.swift
+++ b/Kryptonite/Session.swift
@@ -50,11 +50,11 @@ struct Session:Jsonable {
     }
     
     var object: Object {
-        var objectMap = ["id": id,
+        var objectMap:[String : Any] = ["id": id,
                          "name": pairing.name,
                          "queue": pairing.queue,
                          "created": created.timeIntervalSince1970,
-                         "workstation_public_key": pairing.workstationPublicKey.toBase64()] as [String : Any]
+                         "workstation_public_key": pairing.workstationPublicKey.toBase64()]
         
         if let ver = pairing.version {
             objectMap["version"] = ver.string

--- a/Kryptonite/Sodium.swift
+++ b/Kryptonite/Sodium.swift
@@ -9,17 +9,8 @@
 import Foundation
 import Sodium
 
-struct SodiumInitializationFailure:Error{}
-
-private var sharedSodium : Sodium?
 class KRSodium {
-    class func shared() throws -> Sodium {
-        if let sodium = sharedSodium {
-            return sodium
-        }
-        guard let sodium = Sodium() else {
-            throw SodiumInitializationFailure()
-        }
-        return sodium
+    class func shared() -> Sodium {
+        return Sodium()
     }
 }

--- a/Kryptonite/Sodium.swift
+++ b/Kryptonite/Sodium.swift
@@ -10,7 +10,7 @@ import Foundation
 import Sodium
 
 class KRSodium {
-    class func shared() -> Sodium {
+    class func instance() -> Sodium {
         return Sodium()
     }
 }

--- a/Kryptonite/Wrap.swift
+++ b/Kryptonite/Wrap.swift
@@ -12,7 +12,7 @@ import Sodium
 
 extension Box.PublicKey {
     func wrap(to pk: Box.PublicKey) throws -> Data {
-        guard let wrappedPublicKey = KRSodium.shared().box.seal(message: self, recipientPublicKey: pk)
+        guard let wrappedPublicKey = KRSodium.instance().box.seal(message: self, recipientPublicKey: pk)
         else {
             throw CryptoError.encrypt
         }

--- a/Kryptonite/Wrap.swift
+++ b/Kryptonite/Wrap.swift
@@ -12,7 +12,7 @@ import Sodium
 
 extension Box.PublicKey {
     func wrap(to pk: Box.PublicKey) throws -> Data {
-        guard let wrappedPublicKey = try KRSodium.shared().box.seal(message: self, recipientPublicKey: pk)
+        guard let wrappedPublicKey = KRSodium.shared().box.seal(message: self, recipientPublicKey: pk)
         else {
             throw CryptoError.encrypt
         }

--- a/Lib/M13Checkbox/M13Checkbox.swift
+++ b/Lib/M13Checkbox/M13Checkbox.swift
@@ -456,7 +456,7 @@ public class M13Checkbox: UIControl {
     }
     
     /// The type of mark to display.
-    @IBInspectable public var markType: MarkType {
+    public var markType: MarkType {
         get {
             return controller.markType
         }

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 check:
-	xcodebuild test -project Kryptonite.xcodeproj -scheme Debug -destination 'platform=iOS Simulator,name=iPhone 8' | xcpretty
+	xcodebuild test -project Kryptonite.xcodeproj -scheme Debug -destination 'platform=iOS Simulator,name=iPhone 7' | xcpretty

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 check:
-	xcodebuild test -project Kryptonite.xcodeproj -scheme Debug -destination 'platform=iOS Simulator,name=iPhone 6' | xcpretty
+	xcodebuild test -project Kryptonite.xcodeproj -scheme Debug -destination 'platform=iOS Simulator,name=iPhone 8' | xcpretty


### PR DESCRIPTION
Update swift-sodium: v0.5 + compiles libsodium src

- fix compiler warnings about "complex expressions": remove casting as
[String : Any] and just help the compiler by defining the type
- updates the swift-sodium library to include v0.5, including v1.0.15 of
libsodium.
- libsodium is now compiled from source in swift-sodium project
- Sodium init no longer is optional, so updated KRSodium to not throw;
updated tests correspondingly